### PR TITLE
Open  mail app when support button is clicked

### DIFF
--- a/cypress/e2e/support-button.cy.ts
+++ b/cypress/e2e/support-button.cy.ts
@@ -1,0 +1,29 @@
+describe("support button", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/dashboard");
+  });
+
+  context("desktop resolution", () => {
+    beforeEach(() => {
+      cy.viewport(1025, 900);
+    });
+
+    it("finds support button when navigation is collapsed and when is not", () => {
+      cy.get("button").contains("Support").should("exist");
+      cy.get("nav").contains("Collapse").click();
+      cy.get("img[alt='Support icon']").should("exist");
+    });
+  });
+
+  context("mobile resolution", () => {
+    beforeEach(() => {
+      cy.viewport("iphone-8");
+    });
+
+    it("finds support button when navigation is collapsed and when is not", () => {
+      cy.get("button").contains("Support").should("exist");
+      cy.get("img[alt='open menu']").click();
+      cy.get("img[alt='Support icon']").should("exist");
+    });
+  });
+});

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -195,7 +195,10 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                (window.location.href =
+                  "mailto:support@prolog-app.com?subject=Support Request:")
+              }
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
In this PR I worked on the support button, now when that button is clicked instead of getting an alert is going to open the default mail app of the user's device and is automatically going to fill up the recipient and the subject line