### PR TITLE
fix the wrong logo when switching to mobile view issue

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import styled, { css } from "styled-components";
 import { Routes } from "@config/routes";
 import { NavigationContext } from "./navigation-context";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
+import { useWindowSize } from "hooks/useWindowSize";
 import { Button } from "@features/ui";
 import { breakpoint, color, space, zIndex } from "@styles/theme";
 
@@ -156,15 +157,24 @@ const CollapseMenuItem = styled(MenuItemButton)`
 
 export function SidebarNavigation() {
   const router = useRouter();
+  const [width] = useWindowSize();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isMobileView, setIsMobileView] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    width < 1024 ? setIsMobileView(true) : setIsMobileView(false);
+  }, [width]);
+
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
         <Header>
           <Logo
             src={
-              isSidebarCollapsed
+              isMobileView
+                ? "/icons/logo-large.svg"
+                : isSidebarCollapsed
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }

--- a/hooks/useWindowSize.ts
+++ b/hooks/useWindowSize.ts
@@ -1,0 +1,19 @@
+import React, { useLayoutEffect, useState } from "react";
+
+//This code is to avoid the following warning:
+// Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client.
+if (typeof document === "undefined") {
+  React.useLayoutEffect = React.useEffect;
+}
+export const useWindowSize = (): number[] => {
+  const [windowSize, setWindowSize] = useState([0, 0]);
+  const updateWindowSize = () => {
+    setWindowSize([window.innerWidth, window.innerHeight]);
+  };
+  useLayoutEffect(() => {
+    window.addEventListener("resize", updateWindowSize);
+    updateWindowSize();
+    return () => window.removeEventListener("resize", updateWindowSize);
+  }, []);
+  return [windowSize[0], windowSize[1]];
+};


### PR DESCRIPTION
In this PR I added a custom hook to the codebase to keep track of the window height and width and with that info I can set a state to know if user is on mobileView

then I added a condition that stated that is window is on mobile view it should show the large logo always