### PR TITLE
Fix issue list number of events and users

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list-number-of-events.cy.ts
+++ b/cypress/e2e/issue-list-number-of-events.cy.ts
@@ -1,0 +1,32 @@
+describe("Issue list number of events and users", () => {
+  beforeEach(() => {
+    // open issues page
+    cy.visit(`http://localhost:3000/dashboard/issues
+    `);
+  });
+
+  context("desktop resolution", () => {
+    beforeEach(() => {
+      cy.viewport(1025, 900);
+    });
+
+    it("checks if the numbers in the first two td elements are different", () => {
+      const firstNumber = cy.get("tbody>tr>td").eq(2);
+      const secondNumber = cy.get("tbody>tr>td").eq(3);
+
+      expect(firstNumber).to.not.equal(secondNumber);
+    });
+  });
+
+  context("mobile resolution", () => {
+    beforeEach(() => {
+      cy.viewport("iphone-8");
+    });
+    it("checks if the numbers in the first two td elements are different", () => {
+      const firstNumber = cy.get("tbody>tr>td").eq(2);
+      const secondNumber = cy.get("tbody>tr>td").eq(3);
+
+      expect(firstNumber).to.not.equal(secondNumber);
+    });
+  });
+});

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -48,8 +48,9 @@ const ErrorType = styled.span`
 `;
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
+  console.log(issue);
 
   return (
     <Row>
@@ -72,7 +73,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </Cell>
       <Cell>{numEvents}</Cell>
-      <Cell>{numEvents}</Cell>
+      <Cell>{numUsers}</Cell>
     </Row>
   );
 }

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -50,8 +50,6 @@ const ErrorType = styled.span`
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
   const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
-  console.log(issue);
-
   return (
     <Row>
       <IssueCell>


### PR DESCRIPTION
Fix the issue of events and users having the same number, by checking the request and displaying it in the correct order and position